### PR TITLE
sort history by apply_time first, then by version

### DIFF
--- a/MigrateController.php
+++ b/MigrateController.php
@@ -689,7 +689,7 @@ class MigrateController extends Controller
         $query   = new Query;
         $rows    = $query->select(['version', 'alias', 'apply_time'])
             ->from($this->migrationTable)
-            ->orderBy('version DESC')
+            ->orderBy('apply_time DESC, version DESC')
             ->limit($limit)
             ->createCommand($this->db)
             ->queryAll();


### PR DESCRIPTION
The migration history should be sorted by apply time (just like in the original Yii2 MigrateController). Otherwise we have situations where migrate/down doesn't undo the latest migration.