### PR TITLE
Ability to redo or down a migration by path

### DIFF
--- a/MigrateController.php
+++ b/MigrateController.php
@@ -694,6 +694,9 @@ class MigrateController extends Controller
             $this->createMigrationHistoryTable();
         }
         $query = new Query;
+        if ($this->disableLookup === true) {
+            $query->where(['alias' => $this->migrationPath]);
+        }
         $rows = $query->select(['version', 'alias', 'apply_time'])
             ->from($this->migrationTable)
             ->orderBy('apply_time DESC, version DESC')


### PR DESCRIPTION
**Use case.**
I have some installed packages. Some packages have migrations. I want to remove some of those packages and previously I need to execute `migrate/down` by path for it.

Your migration controller has a property `disableLookup` but it uses for a new migrations only. I do suggest you to use this param in `getMigrationHistory` method. Thus whether user sets a `migrationPath` and a `disableLookup = true` and then `getMigrationHistory` adds a condition `['alias' => $this->migrationPath]` to db query.