### PR TITLE
Checking if default migration path is already in migrationLookup

### DIFF
--- a/MigrateController.php
+++ b/MigrateController.php
@@ -753,10 +753,17 @@ class MigrateController extends Controller
             $this->migrationLookup = ArrayHelper::merge($this->migrationLookup, \Yii::$app->params['yii.migrations']);
         }
 
+        $trimPath = function ($path) {
+            return rtrim(Yii::getAlias($path), DIRECTORY_SEPARATOR);
+        };
+        $directories = array_map($trimPath, $this->migrationLookup);
+
         if ($this->migrationPath && $this->disableLookup) {
             $directories = [$this->migrationPath];
-        } else {
+        } elseif (!in_array($trimPath($this->migrationPath), $directories)) {
             $directories = ArrayHelper::merge([$this->migrationPath], $this->migrationLookup);
+        }else{
+            $directories = $this->migrationLookup;
         }
 
         $migrations = [];


### PR DESCRIPTION
Will be usefull in case when application migrations should be applied only after applying migrations from external packages.